### PR TITLE
docket processing endpoints split to have clear API

### DIFF
--- a/dokito_processing_monolith/src/main.rs
+++ b/dokito_processing_monolith/src/main.rs
@@ -55,10 +55,12 @@ async fn main() -> anyhow::Result<()> {
         tracing::error!(err = %e,"NO INTERNET DETECTED");
         panic!("NO INTERNET DETECTED");
     }
+
     // check address early
     let addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), *PORT);
     info!(?addr, "Starting application on adress");
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+
     // initialise our subscriber
     let make_api = || {
         let routes = define_routes();

--- a/dokito_processing_monolith/src/server/admin_routes.rs
+++ b/dokito_processing_monolith/src/server/admin_routes.rs
@@ -1,3 +1,13 @@
+//! # Admin Routes - Critical System Endpoints
+//!
+//! This module contains ALL critical administrative endpoints for the Dokito processing system.
+//!
+//! ## Key Endpoints Defined Here:
+//! - **Direct File Processing**: Immediate file processing without queue
+//! - **Docket Processing**: All docket-related batch processing operations
+//! - **Temporary Routes**: Development and testing endpoints
+//!
+
 use aide::axum::{
     ApiRouter,
     routing::{post, post_with},
@@ -9,8 +19,31 @@ use crate::server::direct_file_fetch::{
 use crate::server::queue_routes;
 use crate::server::temporary_routes::define_temporary_routes;
 
+/// Creates the complete admin router with ALL critical administrative endpoints.
+///
+/// **IMPORTANT: This function defines ALL admin functionality for the system.**
+///
+/// ## Endpoints Created:
+///
+/// ### Direct File Processing
+/// - `POST /direct_file_attachment_process` - Process files immediately without queuing
+///
+/// ### Docket Processing (All Jurisdictions)
+/// - `POST /docket-process/{state}/{jurisdiction_name}/raw-dockets` - Process raw docket data
+/// - `POST /docket-process/{state}/{jurisdiction_name}/govid/process` - Process docket by government ID
+/// - `POST /docket-process/{state}/{jurisdiction_name}/govid/ingest` - Ingest docket by government ID
+/// - `POST /docket-process/{state}/{jurisdiction_name}/govid/full` - Full process and ingest by government ID
+/// - `POST /docket-process/{state}/{jurisdiction_name}/by-jurisdiction` - Process all dockets by jurisdiction
+/// - `POST /docket-process/{state}/{jurisdiction_name}/by-daterange` - Process dockets within date range
+///
+/// ### Temporary/Development Routes
+/// - Various testing and development endpoints (see temporary_routes module)
+///
+/// ## Returns
+/// A fully configured `ApiRouter` with all admin endpoints mounted and documented.
 pub fn create_admin_router() -> ApiRouter {
     let admin_routes = ApiRouter::new()
+        // Direct file processing - immediate processing without queue
         .api_route(
             "/direct_file_attachment_process",
             post_with(
@@ -18,14 +51,26 @@ pub fn create_admin_router() -> ApiRouter {
                 handle_directly_process_file_request_docs,
             ),
         )
+        // Docket processing endpoints - batch operations for all jurisdictions
         .api_route(
             "/docket-process/{state}/{jurisdiction_name}/raw-dockets",
             post(queue_routes::raw_dockets_endpoint),
         )
+        // Government ID specific endpoints
+        // each takes only a docket_ids: Vec<NonEmptyString>
         .api_route(
-            "/docket-process/{state}/{jurisdiction_name}/by-gov-ids",
-            post(queue_routes::by_ids_endpoint),
+            "/docket-process/{state}/{jurisdiction_name}/govid/process",
+            post(queue_routes::process_by_govid),
         )
+        .api_route(
+            "/docket-process/{state}/{jurisdiction_name}/govid/ingest",
+            post(queue_routes::ingest_by_govid),
+        )
+        .api_route(
+            "/docket-process/{state}/{jurisdiction_name}/govid/full",
+            post(queue_routes::process_and_ingest_by_govid),
+        )
+        // Bulk processing endpoints - handle multiple dockets at once
         .api_route(
             "/docket-process/{state}/{jurisdiction_name}/by-jurisdiction",
             post(queue_routes::by_jurisdiction_endpoint),
@@ -35,6 +80,6 @@ pub fn create_admin_router() -> ApiRouter {
             post(queue_routes::by_daterange_endpoint),
         );
 
-    // Temporary routes are also admin routes
+    // Add temporary/development routes to the admin router
     define_temporary_routes(admin_routes)
 }

--- a/dokito_processing_monolith/src/server/queue_routes.rs
+++ b/dokito_processing_monolith/src/server/queue_routes.rs
@@ -265,7 +265,7 @@ async fn execute_processing_action(
 ) -> Result<ProcessingResponse, String> {
     // NOTE:
     // THIS FUNCTIONS REQUIRES THAT THE DATA HAS ALREDY BEEN
-    // UPOLOADED THROUGH THE RAW DOCKETS ENDPOINT
+    // UPLOADED THROUGH THE RAW DOCKETS ENDPOINT
 
     let s3_client = DIGITALOCEAN_S3.make_s3_client().await;
     let pool = get_dokito_pool().await.map_err(|e| e.to_string())?;


### PR DESCRIPTION
split `/docket-process/{state}/{jurisdiction_name}/by-gov-ids` into 
- `/docket-process/{state}/{jurisdiction_name}/govid/process`
- `/docket-process/{state}/{jurisdiction_name}/govid/ingest`
- `/docket-process/{state}/{jurisdiction_name}/govid/full`
to prevent misunderstanding and misuse